### PR TITLE
Scrape endpoints concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ instances:
     send_distribution_buckets: true
     collect_counters_with_distributions: true
 
+    # Optional: Maximum number of concurrent requests to make to PlanetScale endpoints
+    # Adjust based on your needs and available resources
+    max_concurrent_requests: 1
+
     # Optional OpenMetricsBaseCheck settings (applied to discovered endpoints)
     # tags:
     #   - 'static_tag:value' # Additional static tags added to all metrics

--- a/planetscale.py
+++ b/planetscale.py
@@ -104,7 +104,7 @@ class PlanetScaleCheck(OpenMetricsBaseCheckV2):
 
     def scrape_planetscale_targets(self, instance, targets):
         # Set max workers - adjust based on your needs
-        max_workers = instance.get("max_concurrent_requests", 5)
+        max_workers = instance.get("max_concurrent_requests", 1)
         
         # Create a list to store target configurations for parallel processing
         scrape_configs = []


### PR DESCRIPTION
The agent check takes over a minute in our Planetscale account. I've tested this modified version on our main organisation (11 databases, a mix of some databases with many shards, some with many keyspaces, some with many tables) and it cuts execution from over a minute down to 20s with 5 concurrent requests and 10s with 10 concurrent requests.