### PR TITLE
Add database_tags for per-database tag overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ From their [documentation](https://github.com/DataDog/integrations-core/blob/mas
 *   `namespace`: Prefix added to all collected metrics (e.g., `planetscale.cluster_size`).
 *   `metrics`: A list defining which metrics to collect from the discovered Prometheus endpoints. You can rename metrics or override their types here.
 *   `tags`: Optional static tags to add to all metrics collected by this instance. Discovered labels (like database and branch name) are automatically added as tags prefixed with `ps_`.
+*   `database_tags`: Optional mapping of database name to a list of extra tags, applied only to metrics from that database. Additive on top of `tags`. Each entry can specify one or more tags. Use this when databases in a single org need distinct tagging — for example, mixed environments in one org, per-team ownership, tiering, or compliance scope:
+
+    ```yaml
+    database_tags:
+      my-prod-db: ['env:prod', 'team:billing', 'tier:critical']
+      my-staging-db: ['env:staging']
+      shared-analytics-db: ['team:data', 'tier:standard', 'compliance:pci']
+    ```
 
 ## Validation
 
@@ -118,3 +126,15 @@ From their [documentation](https://github.com/DataDog/integrations-core/blob/mas
 *   **API Connection Issues:** Verify the Service Token ID and Secret are correct and have the necessary permissions in PlanetScale. Check the `planetscale.api.can_connect` service check status. Ensure the Datadog Agent host has network connectivity to `api.planetscale.com`.
 *   **Scraping Errors:** Check the `planetscale.target.can_scrape` service check. Verify the discovered endpoints are accessible from the Agent host and are serving valid OpenMetrics/Prometheus data. Check Agent logs (`agent.log`, `collector.log`) for more detailed errors related to scraping.
 *   **Missing Metrics:** Ensure the metric names in your `planetscale.yaml` `metrics` list exactly match the names exposed by the PlanetScale endpoints (after any potential `prometheus_metrics_prefix` removal). Verify the `namespace` is correct.
+
+## Development
+
+Unit tests cover the check's config construction, tag merging, URL assembly, and API error handling. To run them:
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r tests/requirements.txt
+.venv/bin/pytest
+```
+
+The tests patch `create_scraper` so no Datadog Agent runtime or PlanetScale API credentials are required.

--- a/conf.d/planetscale.yaml.example
+++ b/conf.d/planetscale.yaml.example
@@ -21,6 +21,15 @@ instances:
     send_distribution_buckets: true
     collect_counters_with_distributions: true
 
+    # Optional: Per-database tag overrides. Additive on top of the `tags` list below.
+    # Keys are database names as returned by the PlanetScale API; values are lists of extra tags
+    # applied only to metrics from that database. Each entry can specify one or more tags.
+    # Useful when a single org contains a mix of environments, teams, tiers, etc.
+    # database_tags:
+    #   my-prod-db: ['env:prod', 'team:billing', 'tier:critical']
+    #   my-staging-db: ['env:staging']
+    #   shared-analytics-db: ['team:data', 'tier:standard', 'compliance:pci']
+
     # Optional OpenMetricsBaseCheck settings for discovered endpoints
     # tags:
     #   - 'static_tag:value' # Additional static tags to add to all metrics (dynamic tags are added automatically)

--- a/planetscale.py
+++ b/planetscale.py
@@ -197,6 +197,17 @@ class PlanetScaleCheck(OpenMetricsBaseCheckV2):
             for key, value in discovered_labels.items():
                 if not key.startswith("__"):
                     dynamic_tags.append(f"{key}:{value}")
+
+            # Apply per-database tag overrides, additive on top of the instance-level tags
+            database_tags_config = instance.get("database_tags", {})
+            db_name = discovered_labels.get("planetscale_database_name")
+            if db_name and db_name in database_tags_config:
+                extra_tags = database_tags_config[db_name]
+                dynamic_tags.extend(extra_tags)
+                self.log.debug(
+                    f"Applied database_tags for '{db_name}': {extra_tags}"
+                )
+
             dynamic_instance["tags"] = list(set(dynamic_tags))
 
             # Add to scrape configs instead of scraping immediately

--- a/planetscale.py
+++ b/planetscale.py
@@ -105,6 +105,7 @@ class PlanetScaleCheck(OpenMetricsBaseCheckV2):
     def scrape_planetscale_targets(self, instance, targets):
         # Set max workers - adjust based on your needs
         max_workers = instance.get("max_concurrent_requests", 1)
+        database_tags_config = self._normalize_database_tags(instance.get("database_tags"))
         
         # Create a list to store target configurations for parallel processing
         scrape_configs = []
@@ -199,7 +200,6 @@ class PlanetScaleCheck(OpenMetricsBaseCheckV2):
                     dynamic_tags.append(f"{key}:{value}")
 
             # Apply per-database tag overrides, additive on top of the instance-level tags
-            database_tags_config = instance.get("database_tags", {})
             db_name = discovered_labels.get("planetscale_database_name")
             if db_name and db_name in database_tags_config:
                 extra_tags = database_tags_config[db_name]
@@ -246,3 +246,29 @@ class PlanetScaleCheck(OpenMetricsBaseCheckV2):
                 message=str(e),
                 tags=target_tags,
             )
+
+    def _normalize_database_tags(self, database_tags):
+        if database_tags is None:
+            return {}
+
+        if not isinstance(database_tags, dict):
+            raise ConfigurationError(
+                "Option 'database_tags' must be a mapping of database names to a tag or list of tags."
+            )
+
+        normalized_database_tags = {}
+        for db_name, extra_tags in database_tags.items():
+            if isinstance(extra_tags, str):
+                normalized_database_tags[db_name] = [extra_tags]
+                continue
+
+            if not isinstance(extra_tags, list) or not all(
+                isinstance(tag, str) for tag in extra_tags
+            ):
+                raise ConfigurationError(
+                    f"Option 'database_tags[{db_name}]' must be a string or list of strings."
+                )
+
+            normalized_database_tags[db_name] = extra_tags
+
+        return normalized_database_tags

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+datadog-checks-base[deps]
+requests

--- a/tests/test_planetscale.py
+++ b/tests/test_planetscale.py
@@ -1,0 +1,190 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from datadog_checks.base import AgentCheck, ConfigurationError
+
+from planetscale import PlanetScaleCheck
+
+
+def make_instance(**overrides):
+    instance = {
+        "planetscale_organization": "test-org",
+        "ps_service_token_id": "id",
+        "ps_service_token_secret": "secret",
+        "namespace": "planetscale",
+        "metrics": [".*"],
+    }
+    instance.update(overrides)
+    return instance
+
+
+def make_target(
+    database_name="my-db",
+    branch_name="main",
+    metrics_path="/metrics/branch/abc",
+    host="metrics.planetscale.com",
+    extra_labels=None,
+):
+    labels = {
+        "__metrics_path__": metrics_path,
+        "__param_sig": "sig-value",
+        "__param_exp": "12345",
+        "__scheme__": "https",
+        "planetscale_database_name": database_name,
+        "planetscale_branch_name": branch_name,
+        "planetscale_organization_name": "test-org",
+    }
+    if extra_labels:
+        labels.update(extra_labels)
+    return {"targets": [host], "labels": labels}
+
+
+@pytest.fixture
+def check():
+    return PlanetScaleCheck("planetscale", {}, [make_instance()])
+
+
+@pytest.fixture
+def capture_scraper_configs(check):
+    def run(instance, targets):
+        captured = []
+
+        def side_effect(config):
+            captured.append(config)
+            return MagicMock()
+
+        with patch.object(check, "create_scraper", side_effect=side_effect):
+            check.scrape_planetscale_targets(instance, targets)
+        return captured
+
+    return run
+
+
+def _find_config_for_db(configs, db_name):
+    return next(
+        c for c in configs if f"planetscale_database_name:{db_name}" in c["tags"]
+    )
+
+
+class TestDatabaseTags:
+    def test_applies_tags_for_matching_database(self, capture_scraper_configs):
+        instance = make_instance(database_tags={"my-db": ["env:prod"]})
+        configs = capture_scraper_configs(instance, [make_target(database_name="my-db")])
+        assert "env:prod" in configs[0]["tags"]
+
+    def test_skips_non_matching_database(self, capture_scraper_configs):
+        instance = make_instance(database_tags={"other-db": ["env:prod"]})
+        configs = capture_scraper_configs(instance, [make_target(database_name="my-db")])
+        assert "env:prod" not in configs[0]["tags"]
+
+    def test_additive_with_instance_level_tags(self, capture_scraper_configs):
+        instance = make_instance(
+            tags=["team:infra"],
+            database_tags={"my-db": ["env:prod"]},
+        )
+        configs = capture_scraper_configs(instance, [make_target(database_name="my-db")])
+        assert "team:infra" in configs[0]["tags"]
+        assert "env:prod" in configs[0]["tags"]
+
+    def test_supports_multiple_tags_per_database(self, capture_scraper_configs):
+        instance = make_instance(
+            database_tags={"my-db": ["env:prod", "team:billing", "tier:critical"]},
+        )
+        configs = capture_scraper_configs(instance, [make_target(database_name="my-db")])
+        for tag in ("env:prod", "team:billing", "tier:critical"):
+            assert tag in configs[0]["tags"]
+
+    def test_applies_only_to_matching_target_in_mixed_set(self, capture_scraper_configs):
+        instance = make_instance(database_tags={"prod-db": ["env:prod"]})
+        targets = [
+            make_target(database_name="prod-db"),
+            make_target(database_name="staging-db"),
+        ]
+        configs = capture_scraper_configs(instance, targets)
+        assert "env:prod" in _find_config_for_db(configs, "prod-db")["tags"]
+        assert "env:prod" not in _find_config_for_db(configs, "staging-db")["tags"]
+
+    def test_absent_config_is_noop(self, capture_scraper_configs):
+        configs = capture_scraper_configs(make_instance(), [make_target()])
+        assert not any(t.startswith("env:") for t in configs[0]["tags"])
+
+
+class TestTargetConfig:
+    def test_discovered_labels_become_tags(self, capture_scraper_configs):
+        configs = capture_scraper_configs(
+            make_instance(), [make_target(database_name="my-db", branch_name="main")]
+        )
+        tags = configs[0]["tags"]
+        assert "planetscale_database_name:my-db" in tags
+        assert "planetscale_branch_name:main" in tags
+        assert "planetscale_organization_name:test-org" in tags
+
+    def test_meta_labels_are_not_promoted_to_tags(self, capture_scraper_configs):
+        configs = capture_scraper_configs(make_instance(), [make_target()])
+        tags = configs[0]["tags"]
+        assert not any(t.startswith("__") for t in tags)
+
+    def test_builds_url_from_host_path_and_params(self, capture_scraper_configs):
+        configs = capture_scraper_configs(
+            make_instance(),
+            [make_target(metrics_path="/metrics/branch/xyz", host="api.example.com")],
+        )
+        url = configs[0]["openmetrics_endpoint"]
+        assert url.startswith("https://api.example.com/metrics/branch/xyz")
+        assert "sig=sig-value" in url
+        assert "exp=12345" in url
+
+    def test_adds_scheme_when_host_missing_scheme(self, capture_scraper_configs):
+        configs = capture_scraper_configs(
+            make_instance(), [make_target(host="api.example.com")]
+        )
+        assert configs[0]["openmetrics_endpoint"].startswith("https://")
+
+    def test_skips_target_with_no_targets_field(self, capture_scraper_configs):
+        configs = capture_scraper_configs(
+            make_instance(), [{"labels": {"planetscale_database_name": "x"}}]
+        )
+        assert configs == []
+
+
+class TestCheckValidation:
+    def test_missing_organization_raises(self, check):
+        instance = make_instance()
+        del instance["planetscale_organization"]
+        with pytest.raises(ConfigurationError, match="planetscale_organization"):
+            check.check(instance)
+
+    def test_missing_token_id_raises(self, check):
+        instance = make_instance()
+        del instance["ps_service_token_id"]
+        with pytest.raises(ConfigurationError, match="ps_service_token_id"):
+            check.check(instance)
+
+    def test_missing_token_secret_raises(self, check):
+        instance = make_instance()
+        del instance["ps_service_token_secret"]
+        with pytest.raises(ConfigurationError, match="ps_service_token_secret"):
+            check.check(instance)
+
+
+class TestApiConnectivity:
+    def test_api_failure_emits_critical_service_check(self, check):
+        with patch("planetscale.requests.get") as mock_get, patch.object(
+            check, "service_check"
+        ) as mock_sc:
+            mock_get.side_effect = requests.exceptions.ConnectionError("nope")
+            check.check(make_instance())
+            names_and_statuses = [(c.args[0], c.args[1]) for c in mock_sc.call_args_list]
+            assert ("planetscale.api.can_connect", AgentCheck.CRITICAL) in names_and_statuses
+
+    def test_api_success_emits_ok_service_check(self, check):
+        response = MagicMock()
+        response.json.return_value = []
+        response.raise_for_status.return_value = None
+        with patch("planetscale.requests.get", return_value=response), patch.object(
+            check, "service_check"
+        ) as mock_sc:
+            check.check(make_instance())
+            names_and_statuses = [(c.args[0], c.args[1]) for c in mock_sc.call_args_list]
+            assert ("planetscale.api.can_connect", AgentCheck.OK) in names_and_statuses

--- a/tests/test_planetscale.py
+++ b/tests/test_planetscale.py
@@ -109,6 +109,34 @@ class TestDatabaseTags:
         configs = capture_scraper_configs(make_instance(), [make_target()])
         assert not any(t.startswith("env:") for t in configs[0]["tags"])
 
+    def test_null_config_is_noop(self, capture_scraper_configs):
+        configs = capture_scraper_configs(
+            make_instance(database_tags=None), [make_target()]
+        )
+        assert not any(t.startswith("env:") for t in configs[0]["tags"])
+
+    def test_normalizes_single_tag_string(self, capture_scraper_configs):
+        configs = capture_scraper_configs(
+            make_instance(database_tags={"my-db": "env:prod"}),
+            [make_target(database_name="my-db")],
+        )
+        assert "env:prod" in configs[0]["tags"]
+        assert not any(len(tag) == 1 for tag in configs[0]["tags"])
+
+    def test_invalid_tag_value_raises(self, capture_scraper_configs):
+        with pytest.raises(ConfigurationError, match="database_tags\\[my-db\\]"):
+            capture_scraper_configs(
+                make_instance(database_tags={"my-db": None}),
+                [make_target(database_name="my-db")],
+            )
+
+    def test_invalid_top_level_shape_raises(self, capture_scraper_configs):
+        with pytest.raises(ConfigurationError, match="database_tags"):
+            capture_scraper_configs(
+                make_instance(database_tags=["env:prod"]),
+                [make_target(database_name="my-db")],
+            )
+
 
 class TestTargetConfig:
     def test_discovered_labels_become_tags(self, capture_scraper_configs):


### PR DESCRIPTION
## Summary
- Adds `database_tags` instance config option mapping database name → list of tags. Tags are applied only to metrics from matching databases, additive on top of the existing instance-level `tags`.
- Lookup keys on the `planetscale_database_name` label from the HTTP SD response (confirmed against the `api-bb` metrics controller and its test assertions).
- Useful whenever a single org contains heterogeneous databases needing distinct tags — mixed environments, per-team ownership, tiering, compliance scope, etc.

## What changed
- `planetscale.py`: per-target tag merge now checks `database_tags` and extends `dynamic_tags` when the target's `planetscale_database_name` matches.
- `conf.d/planetscale.yaml.example` and `README.md`: documented the new option with multi-tag examples.
- `tests/`: first unit-test coverage for this check — 16 tests covering config assembly, tag merging (including `database_tags`), URL construction, and service-check emission. Tests patch `create_scraper` so no Agent runtime or PlanetScale credentials are needed.
- `pytest.ini`, `.gitignore`: minimal scaffolding to run tests from a repo-root venv.